### PR TITLE
Fix minimize animation and options link issues

### DIFF
--- a/background.js
+++ b/background.js
@@ -24,8 +24,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     .catch(error => {
       console.error('Error fetching data:', error);
       // Send a more detailed error message
-      sendResponse({ 
-        success: false, 
+      sendResponse({
+        success: false,
         error: error.toString(),
         details: {
           message: error.message,
@@ -33,8 +33,30 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
       });
     });
-    
+
     // Return true to indicate we'll respond asynchronously
+    return true;
+  }
+
+  // Handle opening the options page
+  if (request.type === 'openOptions') {
+    try {
+      if (chrome.runtime.openOptionsPage) {
+        chrome.runtime.openOptionsPage(() => {
+          if (chrome.runtime.lastError) {
+            console.warn('Error opening options page:', chrome.runtime.lastError.message);
+            sendResponse({ success: false, error: chrome.runtime.lastError.message });
+          } else {
+            sendResponse({ success: true });
+          }
+        });
+      } else {
+        sendResponse({ success: false, error: 'openOptionsPage not available' });
+      }
+    } catch (error) {
+      console.error('Error opening options page:', error);
+      sendResponse({ success: false, error: error.toString() });
+    }
     return true;
   }
 });

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "IPv4.Global Marketplace Ticker",
-  "version": "1.20",
+  "version": "1.21",
   "description": "Stock-like ticker displaying real-time IPv4 address block listings, transactions, and prices from the IPv4.Global marketplace, now with an options page.",
   "icons": {
     "16": "assets/icon-16x16.png",


### PR DESCRIPTION
- Fixed minimize animation overshooting the menu button by properly accounting for banner padding (16px) and element margins (6px + 4px + 6px)
- Fixed options link by delegating to background script instead of calling chrome.runtime.openOptionsPage from content script
- Added openOptions message handler in background.js
- Updated version to 1.21

Fixes:
1. Minimize animation now correctly stops at the right edge of the gear menu button
2. Options link now works properly by using background script messaging with fallback to direct URL