### PR TITLE
Fix options link blocking and minimize animation overflow

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "IPv4.Global Marketplace Ticker",
-  "version": "1.20",
+  "version": "1.21",
   "description": "Stock-like ticker displaying real-time IPv4 address block listings, transactions, and prices from the IPv4.Global marketplace, now with an options page.",
   "icons": {
     "16": "assets/icon-16x16.png",


### PR DESCRIPTION
Two bug fixes:

1. Options link blocking (ERR_BLOCKED_BY_CLIENT):
   - Replace window.open() with chrome.tabs.create() for opening options page
   - Chrome blocks window.open() calls with chrome-extension:// URLs as a security measure
   - chrome.tabs.create() is the correct API for opening extension pages

2. Minimize animation overflow:
   - Hide title and scroll container elements BEFORE starting minimize animation
   - Previously elements were hidden AFTER animation, causing content overflow
   - Content now properly hidden during the width transition animation

Version bumped to 1.21