### PR TITLE
Fix menu z-index issue preventing popup from appearing

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -2,7 +2,7 @@
 /* Base styles for the banner */
 .ipv4-banner-base {
   position: fixed !important;
-  z-index: 2147483647 !important;
+  z-index: 2147483646 !important;
   background-color: white !important;
   box-shadow: rgba(0, 0, 0, 0.2) 0px 0px 8px 0px !important;
   color: black !important;


### PR DESCRIPTION
Lower banner z-index from 2147483647 to 2147483646 so the gear submenu (which remains at 2147483647) appears above the ticker banner when clicked. This fixes the issue where clicking the menu button created the popup but it was hidden behind the banner.