### PR TITLE
Fix menu display and ticker font issues

### DIFF
--- a/content.js
+++ b/content.js
@@ -317,8 +317,10 @@
     positionGearSubmenu();
     isGearSubmenuOpen = true;
 
-    // Close when clicking anywhere else
-    document.addEventListener('click', handleClickOutsideGearSubmenu, true);
+    // Close when clicking anywhere else (delayed to avoid immediate closure)
+    setTimeout(() => {
+      document.addEventListener('click', handleClickOutsideGearSubmenu, true);
+    }, 10);
   }
 
   function updateGearSubmenu() {

--- a/styles.css
+++ b/styles.css
@@ -158,24 +158,27 @@
   border-radius: 3px !important;
   padding: 5px 0 !important;
   min-width: 120px !important;
-  display: none !important;
+  display: none;
+  font-family: Arial, sans-serif !important;
+  font-size: 12px !important;
 }
 
 #ipv4-gear-submenu div {
-  padding: 8px 15px; 
-  font-size: 12px;
-  color: #333;
-  cursor: pointer;
-  white-space: nowrap;
+  padding: 8px 15px !important;
+  font-size: 12px !important;
+  font-family: Arial, sans-serif !important;
+  font-weight: normal !important;
+  color: #333 !important;
+  cursor: pointer !important;
+  white-space: nowrap !important;
 }
 
 #ipv4-gear-submenu div:hover {
-  background-color: #f0f0f0;
-  color: #000;
+  background-color: #f0f0f0 !important;
+  color: #000 !important;
 }
 
 #ipv4-banner {
-  font-weight: normal !important;
   text-align: left !important;
   vertical-align: baseline !important;
 }
@@ -187,7 +190,7 @@
   outline: 0 !important;
   margin: 0;
   padding: 0;
-  border: 0; 
+  border: 0;
 }
 
 #ipv4-banner.ipv4-banner-base {


### PR DESCRIPTION
This commit addresses two critical issues:

1. Menu not appearing: Removed `!important` from `display: none` on the gear submenu CSS, which was preventing JavaScript from overriding the display property to show the menu. Also added a 10ms delay before registering the outside-click listener to prevent race conditions.

2. Font styling: Removed `font-weight: normal !important` from the #ipv4-banner CSS rule, which was interfering with the bold font-weight on ticker items (.prefix, .registry, .price classes).

Additional improvements:
- Added explicit font-family and font-weight styling to submenu elements
- Added !important flags to submenu item styles for consistency
- Added !important to hover styles to prevent override conflicts