### PR TITLE
Fix submenu and gear button padding

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -107,19 +107,20 @@
 
 /* Gear button styles (replaces #ipv4-toggle-button) */
 #ipv4-gear-button {
-  font-size: 18px !important; 
+  font-size: 18px !important;
   font-weight: bold;
-  cursor: pointer !important; 
-  color: #555 !important; 
+  cursor: pointer !important;
+  color: #555 !important;
   flex-shrink: 0 !important;
-  padding: 0px 5px !important; 
+  padding: 0px 5px !important;
+  padding-bottom: 3px !important;
   margin-left: 6px !important;
-  line-height: 1 !important; 
+  line-height: 1 !important;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 100%;
-  user-select: none; 
+  user-select: none;
 }
 #ipv4-gear-button:hover {
   color: #000 !important;
@@ -156,7 +157,7 @@
   box-shadow: 0 2px 5px rgba(0,0,0,0.15) !important;
   z-index: 2147483647 !important;
   border-radius: 3px !important;
-  padding: 5px 0 !important;
+  padding: 0 !important;
   min-width: 120px !important;
   display: none;
   font-family: Arial, sans-serif !important;


### PR DESCRIPTION
- Remove 5px padding from #ipv4-gear-submenu
- Add 3px padding-bottom to #ipv4-gear-button for better vertical alignment