### PR TITLE
Make ticker blocks clickable links to auction pages

### DIFF
--- a/content.js
+++ b/content.js
@@ -684,7 +684,25 @@
                     if (CONFIG.debug && (!priceStr || priceStr === "$")) { log.warn('New Listing item missing price or only "$":', item); }
                     if (!priceStr || priceStr === "$") priceStr = '$??';
                 }
-                return `<span class="prefix">/${blockStr}</span> <span class="registry">${regionStr}</span> <span class="price">${priceStr}</span>`;
+
+                // Get auction ID from item (try multiple possible field names)
+                const auctionId = item.auctionId || item.auction_id || item.id || item.listingId || item.listing_id;
+
+                if (CONFIG.debug && auctionId) {
+                    log.info(`Found auction ID for /${blockStr} ${regionStr}: ${auctionId}`);
+                } else if (CONFIG.debug && !auctionId) {
+                    log.warn(`No auction ID found for item:`, item);
+                }
+
+                // Create the ticker content
+                const tickerContent = `<span class="prefix">/${blockStr}</span> <span class="registry">${regionStr}</span> <span class="price">${priceStr}</span>`;
+
+                // Wrap in anchor tag if auction ID exists
+                if (auctionId) {
+                    return `<a href="https://auctions.ipv4.global/auction/${auctionId}" target="_blank" class="ticker-link">${tickerContent}</a>`;
+                } else {
+                    return tickerContent;
+                }
             });
             const validItems = htmlItems.filter(item => item);
 

--- a/styles.css
+++ b/styles.css
@@ -105,6 +105,19 @@
   font-weight: bold !important;
 }
 
+/* Ticker link styles */
+#ipv4-banner .ticker-link {
+  text-decoration: none !important;
+  color: inherit !important;
+  display: inline-block !important;
+  cursor: pointer !important;
+  transition: opacity 0.2s ease !important;
+}
+#ipv4-banner .ticker-link:hover {
+  opacity: 0.7 !important;
+  text-decoration: none !important;
+}
+
 /* Gear button styles (replaces #ipv4-toggle-button) */
 #ipv4-gear-button {
   font-size: 18px !important;


### PR DESCRIPTION
- Extract auction ID from API response (supports multiple field names)
- Wrap each ticker block in anchor tag linking to auction detail page
- Add hover effect with opacity transition for better UX
- Include debug logging to track auction ID extraction
- Gracefully handle missing auction IDs by displaying unlinked ticker