### PR TITLE
Add clickable links to ticker blocks for auction pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -106,6 +106,21 @@
   font-weight: bold !important;
 }
 
+/* Ticker link styling */
+#ipv4-banner .ticker-link {
+  text-decoration: none !important;
+  cursor: pointer !important;
+  display: inline-block !important;
+  transition: opacity 0.2s ease !important;
+}
+#ipv4-banner .ticker-link:hover {
+  opacity: 0.8 !important;
+  text-decoration: none !important;
+}
+#ipv4-banner .ticker-link:visited {
+  text-decoration: none !important;
+}
+
 /* Gear button styles (replaces #ipv4-toggle-button) */
 #ipv4-gear-button {
   font-size: 18px !important;


### PR DESCRIPTION
- Added getAuctionId() helper function to extract auction IDs from API responses
- Modified renderItems() to wrap each ticker block in an anchor tag
- Links point to https://auctions.ipv4.global/auction/{auctionId}
- Added CSS styling for ticker-link class with hover effects
- Supports multiple auction ID field names (auctionId, auction_id, id, etc.)