### PR TITLE
Adjust logo max-height for expanded vs minimized states

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -67,8 +67,15 @@
 }
 
 #ipv4-logo {
+  max-height: 13px !important;
+  margin-top: 2px !important;
   object-fit: contain !important;
   display: block !important;
+}
+
+/* Logo styling when banner is minimized */
+.ipv4-banner-minimized #ipv4-logo {
+  max-height: 16px !important;
 }
 
 /* Scrolling container */


### PR DESCRIPTION
Set logo to 13px max-height when expanded and 16px when minimized to optimize visual appearance in both states.