### PR TITLE
Add 10px left margin to banner title when expanded

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -53,7 +53,12 @@
   margin-right: 0 !important;
   white-space: nowrap !important;
   flex-shrink: 0 !important;
-  cursor: pointer !important; 
+  cursor: pointer !important;
+}
+
+/* Title styling when banner is expanded (not minimized) */
+#ipv4-banner:not(.ipv4-banner-minimized) .banner-title-style {
+  margin-left: 10px !important;
 }
 
 /* Logo styling */


### PR DESCRIPTION
Apply margin-left: 10px to .banner-title-style only when the banner is in expanded state (not minimized). The minimized state retains the original 4px margin.