### PR TITLE
Fix drag handle and gear button margins when minimized

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -182,6 +182,16 @@
   margin: 1px 0 !important;
 }
 
+/* Drag handle styling when banner is minimized */
+.ipv4-banner-minimized #ipv4-drag-handle {
+  margin-right: 4px !important;
+}
+
+/* Gear button styling when banner is minimized */
+.ipv4-banner-minimized #ipv4-gear-button {
+  margin-right: 0px !important;
+}
+
 /* Submenu for Gear Icon */
 #ipv4-gear-submenu {
   /* Free-floating overlay, not clipped by the banner */


### PR DESCRIPTION
- Set drag handle margin-right to 4px when banner is minimized
- Set gear button margin-right to 0px when banner is minimized
- Keep original margins when banner is expanded