### PR TITLE
Adjust banner title margin to 9px

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -58,7 +58,7 @@
 
 /* Title styling when banner is expanded (not minimized) */
 #ipv4-banner:not(.ipv4-banner-minimized) .banner-title-style {
-  margin-left: 10px !important;
+  margin-left: 9px !important;
 }
 
 /* Logo styling */


### PR DESCRIPTION
Changed margin-left from 10px to 9px for the banner title when the banner is expanded (not minimized).