### PR TITLE
Harden ticker CSS against external stylesheet interference

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -33,7 +33,7 @@
 .ipv4-banner-minimized {
   /* Let JS control the width via inline styles */
   /* Safety: never exceed viewport width */
-  max-width: 100vw;
+  max-width: 100vw !important;
 }
 
 /* Utility class to hide elements - Scoped to #ipv4-banner */
@@ -142,7 +142,7 @@
 /* Gear button styles (replaces #ipv4-toggle-button) */
 #ipv4-gear-button {
   font-size: 18px !important;
-  font-weight: bold;
+  font-weight: bold !important;
   cursor: pointer !important;
   color: #555 !important;
   flex-shrink: 0 !important;
@@ -150,11 +150,11 @@
   padding-bottom: 3px !important;
   margin-left: 6px !important;
   line-height: 1 !important;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  height: 100%;
-  user-select: none;
+  display: flex !important;
+  align-items: center !important;
+  justify-content: center !important;
+  height: 100% !important;
+  user-select: none !important;
 }
 #ipv4-gear-button:hover {
   color: #000 !important;
@@ -203,7 +203,7 @@
   border-radius: 3px !important;
   padding: 0 !important;
   min-width: 120px !important;
-  display: none;
+  display: none !important;
   font-family: Arial, sans-serif !important;
   font-size: 12px !important;
 }
@@ -233,9 +233,38 @@
   text-shadow: none !important;
   box-shadow: none !important;
   outline: 0 !important;
-  margin: 0;
-  padding: 0;
-  border: 0;
+  margin: 0 !important;
+  padding: 0 !important;
+  border: 0 !important;
+  /* Additional defensive resets for maximum resilience against external CSS */
+  /* Safe resets that don't interfere with ticker's intentional styles */
+  filter: none !important;
+  backdrop-filter: none !important;
+  clip-path: none !important;
+  mask: none !important;
+  mix-blend-mode: normal !important;
+  float: none !important;
+  clear: none !important;
+  text-indent: 0 !important;
+  font-variant: normal !important;
+  font-stretch: normal !important;
+  word-break: normal !important;
+  hyphens: none !important;
+  writing-mode: horizontal-tb !important;
+  direction: ltr !important;
+  unicode-bidi: normal !important;
+  pointer-events: auto !important;
+  resize: none !important;
+  list-style: none !important;
+  quotes: none !important;
+  counter-reset: none !important;
+  counter-increment: none !important;
+  speak: normal !important;
+  orphans: 2 !important;
+  widows: 2 !important;
+  page-break-after: auto !important;
+  page-break-before: auto !important;
+  page-break-inside: auto !important;
 }
 
 #ipv4-banner.ipv4-banner-base {


### PR DESCRIPTION
Add !important declarations to all remaining properties that lacked them:
- Universal reset (margin, padding, border)
- Gear button layout properties
- Banner minimized state max-width
- Gear submenu display property

Add comprehensive defensive CSS resets to protect against:
- Visual effects (filter, backdrop-filter, clip-path, mask, mix-blend-mode)
- Layout manipulation (float, clear, writing-mode, direction)
- Text rendering edge cases (word-break, hyphens, text-indent)
- Interaction interference (pointer-events, resize)
- Print media quirks (page-break-*, orphans, widows)

These changes make the ticker maximally resilient to aggressive page styles (SASS variables, global resets, framework CSS) without breaking the ticker's own animations, transitions, or intentional styling.